### PR TITLE
Set evm_version to 'paris'

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,9 +1,11 @@
 [profile.default]
 src = 'contracts'
+solc = '0.8.17'
 out = 'out'
 libs = ['lib']
 test = 'contracts/v0.8/test'
 cache_path = 'foundry-cache'
 optimizer = false
+evm_version = 'paris'
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
## Description

Because there is at least one contract whose solc version is `^0.8.17` and `^0.8.0` we must consider that someone can use this library in its own project and compile it using solc version `0.8.20` or above. The problem is that since solc version `0.8.20` the default evm_version is set to 'shanghai' to support the PUSH0 - newly added opcode to the Ethereum blockchain. Since Filecoin, at least for now, does not support PUSH0, deploying a smart contract whose bytecode contains PUSH0 opcode will revert. 

To prevent this from happening, we set `evm_version` manually to 'paris' in the config file.