### PR TITLE
Smoke tests

### DIFF
--- a/testing/smoke_tests.sh
+++ b/testing/smoke_tests.sh
@@ -4,7 +4,7 @@
 ./bin/solc contracts/**/*.sol \
   solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
   @ensdomains=${PWD}/node_modules/@ensdomains/ \
-  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  @zondax/solidity-bignumber/=vendor/solidity-BigNumber/ \
   -o output \
   --evm-version london \
   --metadata \
@@ -22,7 +22,7 @@ fi
 ./bin/solc contracts/**/*.sol \
   solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
   @ensdomains=${PWD}/node_modules/@ensdomains/ \
-  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  @zondax/solidity-bignumber/=vendor/solidity-BigNumber/ \
   -o output \
   --evm-version london \
   --optimize \
@@ -41,7 +41,7 @@ fi
 ./bin/solc contracts/**/*.sol \
   solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
   @ensdomains=${PWD}/node_modules/@ensdomains/ \
-  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  @zondax/solidity-bignumber/=vendor/solidity-BigNumber/ \
   -o output \
   --evm-version london \
   --optimize \

--- a/testing/smoke_tests.sh
+++ b/testing/smoke_tests.sh
@@ -1,0 +1,75 @@
+# No optimization
+## --via-ir false
+./bin/solc contracts/**/*.sol \
+  solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
+  @ensdomains=${PWD}/node_modules/@ensdomains/ \
+  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  -o output \
+  --evm-version london \
+  --metadata \
+  --overwrite
+
+if [ $? -eq 0 ];
+then
+  echo "Compiled without ir and without optimization successfully."
+else
+  echo "Failed to compile without ir and without optimization."
+fi
+
+## --via-ir true
+./bin/solc contracts/**/*.sol \
+  solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
+  @ensdomains=${PWD}/node_modules/@ensdomains/ \
+  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  -o output \
+  --evm-version london \
+  --via-ir \
+  --metadata \
+  --overwrite
+
+if [ $? -eq 0 ];
+then
+  echo "Compiled with ir and without optimization successfully."
+else
+  echo "Failed to compile with ir and without optimization."
+fi
+
+# Optimizided
+## --via-ir false
+./bin/solc contracts/**/*.sol \
+  solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
+  @ensdomains=${PWD}/node_modules/@ensdomains/ \
+  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  -o output \
+  --evm-version london \
+  --optimize \
+  --optimize-runs 10000 \
+  --metadata \
+  --overwrite
+
+if [ $? -eq 0 ];
+then
+  echo "Compiled without ir and with optimization successfully."
+else
+  echo "Failed to compile without ir and with optimization."
+fi
+
+## --via-ir true
+./bin/solc contracts/**/*.sol \
+  solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
+  @ensdomains=${PWD}/node_modules/@ensdomains/ \
+  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
+  -o output \
+  --evm-version london \
+  --optimize \
+  --optimize-runs 10000 \
+  --via-ir \
+  --metadata \
+  --overwrite
+
+if [ $? -eq 0 ];
+then
+  echo "Compiled with ir and with optimization successfully."
+else
+  echo "Failed to compile with ir and with optimization."
+fi

--- a/testing/smoke_tests.sh
+++ b/testing/smoke_tests.sh
@@ -1,5 +1,6 @@
+#!/bin/zsh
+
 # No optimization
-## --via-ir false
 ./bin/solc contracts/**/*.sol \
   solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
   @ensdomains=${PWD}/node_modules/@ensdomains/ \
@@ -11,27 +12,9 @@
 
 if [ $? -eq 0 ];
 then
-  echo "Compiled without ir and without optimization successfully."
+  echo "Compiled without optimization successfully."
 else
-  echo "Failed to compile without ir and without optimization."
-fi
-
-## --via-ir true
-./bin/solc contracts/**/*.sol \
-  solidity-cborutils=${PWD}/node_modules/solidity-cborutils/ \
-  @ensdomains=${PWD}/node_modules/@ensdomains/ \
-  @zondax/solidity-bignumber/=lib/solidity-BigNumber/ \
-  -o output \
-  --evm-version london \
-  --via-ir \
-  --metadata \
-  --overwrite
-
-if [ $? -eq 0 ];
-then
-  echo "Compiled with ir and without optimization successfully."
-else
-  echo "Failed to compile with ir and without optimization."
+  echo "Failed to compile without optimization."
 fi
 
 # Optimizided


### PR DESCRIPTION
Added a sample script for running compilations.
Can't find an option for optimizing constructors only.
Paris is not available for their solc version:

1. We can either use our local solc version, which doesn't make much sense since they install it in the root dir
2. We can update their solc version
3. Or just use an earlier version -> london works

<img width="354" alt="Screenshot 2023-07-24 at 20 00 28" src="https://github.com/MVPWorkshop/filecoin-solidity/assets/10870130/d0523d2f-2782-4128-91ba-3d5aa0922913">
